### PR TITLE
Update golang.org/x/image to v0.38.0 and Go to 1.26.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,7 +23,10 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - uses: actions/setup-go@v6
+        with:
+          go-version: go.mod
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -25,7 +25,7 @@ jobs:
             ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       - uses: actions/setup-go@v6
         with:
-          go-version: go.mod
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: 1.26
       - name: Cache-Go
         uses: actions/cache@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.26.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/cmd/fontlengths/root.go
+++ b/cmd/fontlengths/root.go
@@ -60,7 +60,7 @@ type RootCmd struct {
 
 func (c *RootCmd) Usage() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
-	c.FlagSet.PrintDefaults()
+	c.PrintDefaults()
 	fmt.Fprintln(os.Stderr, "  Commands:")
 	for name := range c.Commands {
 		fmt.Fprintf(os.Stderr, "    %s\n", name)
@@ -69,7 +69,7 @@ func (c *RootCmd) Usage() {
 
 func (c *RootCmd) UsageRecursive() {
 	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
-	c.FlagSet.PrintDefaults()
+	c.PrintDefaults()
 	fmt.Fprintln(os.Stderr, "  Commands:")
 	fmt.Fprintf(os.Stderr, "    %s\n", "generate")
 }
@@ -124,10 +124,10 @@ func NewRoot(name, version, commit, date string) (*RootCmd, error) {
 }
 
 func (c *RootCmd) Execute(args []string) error {
-	if err := c.FlagSet.Parse(args); err != nil {
+	if err := c.Parse(args); err != nil {
 		return NewUserError(err, fmt.Sprintf("flag parse error %s", err.Error()))
 	}
-	remainingArgs := c.FlagSet.Args()
+	remainingArgs := c.Args()
 	if len(remainingArgs) < 1 {
 		c.Usage()
 		return nil

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,13 @@
 module fontlengths
 
-go 1.24.4
+go 1.26.2
 
 require (
 	github.com/arran4/golang-wordwrap v0.0.3
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
-	golang.org/x/image v0.33.0
+	golang.org/x/image v0.38.0
 )
 
 require github.com/flopp/go-findfont v0.1.0
 
-require (
-	github.com/arran4/go-subcommand v0.0.17 // indirect
-	golang.org/x/mod v0.31.0 // indirect
-	golang.org/x/text v0.32.0 // indirect
-)
+require golang.org/x/text v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/arran4/go-subcommand v0.0.17 h1:E9OUENNk603ocfWHcHkebhgQc5ekHSo3pESAFvUFkgY=
-github.com/arran4/go-subcommand v0.0.17/go.mod h1:LEAmrgQ24G7UJfki/zk+TLr3AwIX+JA2CkpSYvVGAbQ=
 github.com/arran4/golang-wordwrap v0.0.3 h1:HKhFpOv44nsN3mnnJzhItRNcZVSk90OO4YbeS/vignk=
 github.com/arran4/golang-wordwrap v0.0.3/go.mod h1:mprS0JTaay8pocrSBwoUltV5WDz12v99EUN1a9z2GAM=
 github.com/flopp/go-findfont v0.1.0 h1:lPn0BymDUtJo+ZkV01VS3661HL6F4qFlkhcJN55u6mU=
@@ -8,11 +6,7 @@ github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF0
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
-golang.org/x/image v0.33.0 h1:LXRZRnv1+zGd5XBUVRFmYEphyyKJjQjCRiOuAP3sZfQ=
-golang.org/x/image v0.33.0/go.mod h1:DD3OsTYT9chzuzTQt+zMcOlBHgfoKQb1gry8p76Y1sc=
-golang.org/x/mod v0.31.0 h1:HaW9xtz0+kOcWKwli0ZXy79Ix+UW/vOfmWI5QVd2tgI=
-golang.org/x/mod v0.31.0/go.mod h1:43JraMp9cGx1Rx3AqioxrbrhNsLl2l/iNAvuBkrezpg=
-golang.org/x/text v0.31.0 h1:aC8ghyu4JhP8VojJ2lEHBnochRno1sgL6nEi9WGFGMM=
-golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
-golang.org/x/text v0.32.0 h1:ZD01bjUt1FQ9WJ0ClOL5vxgxOI/sVCNgX1YtKwcY0mU=
-golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
+golang.org/x/image v0.38.0 h1:5l+q+Y9JDC7mBOMjo4/aPhMDcxEptsX+Tt3GgRQRPuE=
+golang.org/x/image v0.38.0/go.mod h1:/3f6vaXC+6CEanU4KJxbcUZyEePbyKbaLoDOe4ehFYY=
+golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
+golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=


### PR DESCRIPTION
Update golang.org/x/image to v0.38.0 to resolve a known security vulnerability. This inherently required a Go version update. Following instructions, Go has been upgraded to 1.26.2 in go.mod, go.sum, and GitHub Action workflows.

---
*PR created automatically by Jules for task [15609820340488747435](https://jules.google.com/task/15609820340488747435) started by @arran4*